### PR TITLE
Change base to s2i-thoth

### DIFF
--- a/Dockerfile.search_repos
+++ b/Dockerfile.search_repos
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM quay.io/thoth-station/s2i-thoth-f32-py38
 
 MAINTAINER Samuel Macko "samuel.macko.sm@gmail.com"
 


### PR DESCRIPTION
```
error: build error: failed to pull image: After retrying 2 times, Pull image still failed due to error: while pulling "docker://python:3.8" as "python:3.8": Error initializing source docker://python:3.8: Error reading manifest 3.8 in docker.io/library/python: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```