### PR TITLE
Use Thoth s2i as a base image

### DIFF
--- a/Dockerfile.search_repos
+++ b/Dockerfile.search_repos
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM quay.io/thoth-station/s2i-thoth-f32-py38
 
 MAINTAINER Samuel Macko "samuel.macko.sm@gmail.com"
 


### PR DESCRIPTION
Fixes the following error in the cluster:

```
Cloning "https://github.com/samuelmacko/master_thesis" ...
	Commit:	916ffe87527f13169d9b39806e21fd936a868cfe (rework waiting for api calls)
	Author:	samuelmacko <samuel.macko.sm@gmail.com>
	Date:	Sat Jan 16 12:39:51 2021 +0100
Caching blobs under "/var/cache/blobs".

Pulling image python:3.8 ...
Warning: Pull failed, retrying in 5s ...
Warning: Pull failed, retrying in 5s ...
Warning: Pull failed, retrying in 5s ...
error: build error: failed to pull image: After retrying 2 times, Pull image still failed due to error: while pulling "docker://python:3.8" as "python:3.8": Error initializing source docker://python:3.8: Error reading manifest 3.8 in docker.io/library/python: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```